### PR TITLE
Bump Sphinx to 1.4.9

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -36,6 +36,6 @@ commands = flake8 .
 [testenv:docs]
 changedir = docs
 deps =
-  sphinx==1.4.8
+  sphinx==1.4.9
   sphinx-rtd-theme==0.1.9
 commands = sphinx-build -W -b html -d {envtmpdir}/doctrees . {envtmpdir}/html


### PR DESCRIPTION
Ran this locally with Python 2.7.10 (sorry, haven't yet done so with Python 3.x), and it passes that:

https://pastebin.mozilla.org/8933131